### PR TITLE
Bug fix for loss of filter name on clone

### DIFF
--- a/wagtailmodelchooser/edit_handlers.py
+++ b/wagtailmodelchooser/edit_handlers.py
@@ -19,6 +19,16 @@ class ModelChooserPanel(BaseChooserPanel):
         if filter_name is not None:
             FILTERS[filter_name] = filter
 
+    def clone(self):
+        return self.__class__(
+            field_name=self.field_name,
+            filter_name=self.filter_name,
+            widget=self.widget if hasattr(self, 'widget') else None,
+            heading=self.heading,
+            classname=self.classname,
+            help_text=self.help_text
+        )
+
     def widget_overrides(self):
         return {self.field_name: AdminModelChooser(
             model=self.target_model, filter_name=self.filter_name)}


### PR DESCRIPTION
When a ModelChooserPanel's clone method is called, it will lose its filter_name if it has any. This breaks usage of filter_name on ModelChooserPanels on an InlinePanel for instance.

This pull request fixes this by also cloning the filter_name.