### PR TITLE
Increase ajax timeout to 250

### DIFF
--- a/wagtailmodelchooser/static/wagtailmodelchooser/js/model_chooser.js
+++ b/wagtailmodelchooser/static/wagtailmodelchooser/js/model_chooser.js
@@ -46,7 +46,7 @@ function setupModal(modal, jsonData) {
     searchForm.submit(search);
     var searchFieldChange = function(e) {
         clearTimeout($.data(this, 'timer'));
-        var wait = setTimeout(search, 100);
+        var wait = setTimeout(search, 250);
         $(this).data('timer', wait);
     }
     searchForm.on('input', searchFieldChange);


### PR DESCRIPTION
First off, great app! Thanks!

Second, after using the app for a few days, I noticed that the default 100ms delay for the ajax search is not enough to avoid unnecessary requests. 250ms seems to be still fast enough, but avoids many requests. This is the implemented delay in Django autocomplete fields.

https://code.djangoproject.com/ticket/30722
https://github.com/django/django/commit/8f6860863e34cb1cbe24161f1c4e7c79007e93dc

Hope this helps,