### PR TITLE
Use the search backend directly when searching custom models

### DIFF
--- a/tests/app/migrations/0001_initial.py
+++ b/tests/app/migrations/0001_initial.py
@@ -27,6 +27,13 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
+            name='DefaultManagerAuthor',
+            fields=[
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=255)),
+            ],
+        ),
+        migrations.CreateModel(
             name='Book',
             fields=[
                 ('page_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='wagtailcore.Page')),

--- a/tests/app/models.py
+++ b/tests/app/models.py
@@ -32,6 +32,21 @@ class Author(models.Model, index.Indexed):
         return self.name
 
 
+@register_model_chooser(icon='user')
+class DefaultManagerAuthor(models.Model, index.Indexed):
+    name = models.CharField(max_length=255)
+
+    search_fields = [
+        index.SearchField('name'),
+    ]
+
+    class Meta:
+        ordering = ['name']
+
+    def __str__(self):
+        return self.name
+
+
 class Book(Page):
     author = models.ForeignKey(Author, on_delete=models.PROTECT)
 

--- a/tests/test_chooser_view.py
+++ b/tests/test_chooser_view.py
@@ -3,16 +3,17 @@ from django.urls import reverse
 from wagtail.core.models import Page
 from wagtail.tests.utils import WagtailTestUtils
 
-from tests.app.models import Author
+from tests.app.models import Author, DefaultManagerAuthor
 
 
-class TestAdminForm(WagtailTestUtils, TestCase):
+class TestAdminFormSearchable(WagtailTestUtils, TestCase):
     chooser_url = reverse('model_chooser', kwargs={
         'app_label': Author._meta.app_label,
-        'model_name': Author._meta.model_name})
+        'model_name': Author._meta.model_name
+    })
 
     def setUp(self):
-        super(TestAdminForm, self).setUp()
+        super(TestAdminFormSearchable, self).setUp()
 
         self.login()
         self.home_page = Page.objects.get(pk=2)
@@ -28,6 +29,38 @@ class TestAdminForm(WagtailTestUtils, TestCase):
             self.assertContains(response, author.name)
 
     def test_chooser_search(self):
+        response = self.client.get(self.chooser_url, {'q': 'le'})
+        self.assertContains(response, self.ann.name)
+        self.assertContains(response, self.ursula.name)
+        self.assertNotContains(response, self.iain.name)
+        self.assertNotContains(response, self.terry.name)
+
+
+class TestAdminFormBackend(WagtailTestUtils, TestCase):
+    chooser_url = reverse('model_chooser', kwargs={
+        'app_label': DefaultManagerAuthor._meta.app_label,
+        'model_name': DefaultManagerAuthor._meta.model_name
+    })
+
+    def setUp(self):
+        super(TestAdminFormBackend, self).setUp()
+
+        self.login()
+        self.home_page = Page.objects.get(pk=2)
+
+        self.ann = DefaultManagerAuthor.objects.create(name='Ann Leckie')
+        self.iain = DefaultManagerAuthor.objects.create(name='Iain M. Banks')
+        self.ursula = DefaultManagerAuthor.objects.create(
+            name='Ursula K. Le Guin'
+        )
+        self.terry = DefaultManagerAuthor.objects.create(name='Terry Pratchett')
+
+    def test_chooser_view(self):
+        response = self.client.get(self.chooser_url)
+        for author in Author.objects.all():
+            self.assertContains(response, author.name)
+
+    def test_chooser_search_backend(self):
         response = self.client.get(self.chooser_url, {'q': 'le'})
         self.assertContains(response, self.ann.name)
         self.assertContains(response, self.ursula.name)

--- a/wagtailmodelchooser/views.py
+++ b/wagtailmodelchooser/views.py
@@ -5,6 +5,7 @@ from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
 from django.http import Http404
 from django.shortcuts import render
 from wagtail.admin.modal_workflow import render_modal_workflow
+from wagtail.search.backends import get_search_backend
 from wagtail.search.index import Indexed
 
 from . import registry
@@ -53,7 +54,11 @@ def chooser(request, app_label, model_name, filter_name=None):
     is_searching = is_searchable and request.GET.get('q')
 
     if is_searching:
-        qs = qs.search(request.GET['q'])
+        try:
+            qs = qs.search(request.GET['q'])
+        except AttributeError:
+            s = get_search_backend()
+            qs = s.search(request.GET['q'], qs)
 
     if filter_name is not None:
         try:


### PR DESCRIPTION
Hi there. 

Models that don't inherit from `Page` (et al.) need to [use the relevant search backend directly](https://docs.wagtail.io/en/v2.9/topics/search/searching.html#searching-images-documents-and-custom-models) in order to be filtered as their querysets do not have the [necessary `search` method](https://github.com/wagtail/wagtail/blob/06303c7169c8e139e809fe78a96ab7f3828676fe/wagtail/search/queryset.py#L5).

It seems that this fact was being concealed by the test suite because your `Author` model fixture is designated with a queryset inheriting from `SearchableQuerySetMixin`, but in most cases (like mine) this would not be the case.

I've added a fix to handle the scenario where a user wants to search across a vanilla `models.Model` definition that does not have a custom queryset and I've added tests to this end.

Thanks for all the effort, I appreciate the code.