### PR TITLE
Wagtail 2.13 compatibility

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,4 +1,5 @@
 import os
+from wagtail import VERSION as WAGTAIL_VERSION
 
 INSTALLED_APPS = [
     'wagtailmodelchooser',
@@ -51,9 +52,10 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-
-    'wagtail.core.middleware.SiteMiddleware',
 ]
+
+if WAGTAIL_VERSION < (2, 9):
+    MIDDLEWARE.append('wagtail.core.middleware.SiteMiddleware')
 
 TEMPLATES = [
     {

--- a/wagtailmodelchooser/blocks.py
+++ b/wagtailmodelchooser/blocks.py
@@ -32,6 +32,9 @@ class ModelChooserBlock(ChooserBlock):
     def chooser(self):
         return registry.choosers[self.target_model]
 
+    def get_form_state(self, value):
+        return self.widget.get_value_data(value)
+
     def deconstruct(self):
         name, args, kwargs = super(ModelChooserBlock, self).deconstruct()
 

--- a/wagtailmodelchooser/static/wagtailmodelchooser/js/model_chooser_telepath.js
+++ b/wagtailmodelchooser/static/wagtailmodelchooser/js/model_chooser_telepath.js
@@ -1,0 +1,15 @@
+(function() {
+    function ModelChooser(html, modalUrl) {
+        this.html = html;
+        this.modalUrl = modalUrl;
+    }
+    ModelChooser.prototype.render = function(placeholder, name, id, initialState) {
+        var html = this.html.replace(/__NAME__/g, name).replace(/__ID__/g, id);
+        placeholder.outerHTML = html;
+        var chooser = window.wagtail.ui.ModelChooser.setupWagtailWidget(id, this.modalUrl);
+        chooser.setState(initialState);
+        return chooser;
+    };
+
+    window.telepath.register('wagtailmodelchooser.widgets.ModelChooser', ModelChooser);
+})();

--- a/wagtailmodelchooser/templates/wagtailmodelchooser/model_chooser.html
+++ b/wagtailmodelchooser/templates/wagtailmodelchooser/model_chooser.html
@@ -5,5 +5,3 @@
 {% block chosen_state_view %}
     <span class="title">{{ item }}</span>
 {% endblock %}
-
-{% block edit_chosen_item_url %}{% if item %}{% url 'wagtailsnippets:edit' model_opts.app_label model_opts.model_name item.id %}{% endif %}{% endblock %}

--- a/wagtailmodelchooser/templates/wagtailmodelchooser/model_chooser.html
+++ b/wagtailmodelchooser/templates/wagtailmodelchooser/model_chooser.html
@@ -3,5 +3,5 @@
 {% block chooser_class %}model-chooser{% endblock %}
 
 {% block chosen_state_view %}
-    <span class="title">{{ item }}</span>
+    <span class="title">{{ display_title }}</span>
 {% endblock %}


### PR DESCRIPTION
The new StreamField implementation in Wagtail 2.13 requires some heavy rewrites for chooser widgets, since it needs to be able to create and populate them dynamically on the client-side (and the default approach that works for plain input fields - cloning the HTML and writing the `value` attribute - doesn't work, since we need to fill in the text label; and in turn that means passing it extra state that's normally only available server-side). This PR implements those changes, while hopefully remaining backwards compatible with older Wagtail versions.