### PR TITLE
Fix version check for WidgetWithScript.get_value_data

### DIFF
--- a/wagtailmodelchooser/widgets.py
+++ b/wagtailmodelchooser/widgets.py
@@ -47,8 +47,8 @@ class AdminModelChooser(AdminChooser):
         }
 
     def render_html(self, name, value, attrs):
-        if WAGTAIL_VERSION >= (2, 13):
-            # From Wagtail 2.13, get_value_data is called as a preprocessing step in
+        if WAGTAIL_VERSION >= (2, 12):
+            # From Wagtail 2.12, get_value_data is called as a preprocessing step in
             # WidgetWithScript before invoking render_html
             value_data = value or {}
         else:


### PR DESCRIPTION
Sorry, it seems I slipped up with one of the version checks in #27 - [get_value_data was introduced in 2.12, not 2.13](https://github.com/wagtail/wagtail/commit/58927f91dcddb27bedc6023d99894f396a156b43), so I suspect this will break things on 2.12 due to it being called twice.

See also: https://github.com/wagtail/wagtail-generic-chooser/pull/32, https://github.com/ixc/wagtail-instance-selector/issues/15