### PR TITLE
fix: use re_path instead of urls

### DIFF
--- a/wagtailmodelchooser/urls.py
+++ b/wagtailmodelchooser/urls.py
@@ -1,12 +1,12 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from . import views
 
 urlpatterns = [
-    url(r'^chooser/(?P<app_label>[a-zA-Z0-9_]+)/(?P<model_name>[a-zA-Z0-9_]+)/$',
+    re_path(r'^chooser/(?P<app_label>[a-zA-Z0-9_]+)/(?P<model_name>[a-zA-Z0-9_]+)/$',
         views.chooser,
         name='model_chooser'),
-    url(r'^chooser/(?P<app_label>[a-zA-Z0-9_]+)/(?P<model_name>[a-zA-Z0-9_]+)/(?P<filter_name>.+)/$',
+    re_path(r'^chooser/(?P<app_label>[a-zA-Z0-9_]+)/(?P<model_name>[a-zA-Z0-9_]+)/(?P<filter_name>.+)/$',
         views.chooser,
         name='model_chooser'),
 ]


### PR DESCRIPTION
this is needed for django 4.0 compatibility

together with https://github.com/neon-jungle/wagtailmodelchooser/pull/32 this should add full django v4 compatibility and keeps compatibility with wagtail and django 2.2