### PR TITLE
implemented getTextLabel from the StreamField's widget api

### DIFF
--- a/wagtailmodelchooser/static/wagtailmodelchooser/js/model_chooser.js
+++ b/wagtailmodelchooser/static/wagtailmodelchooser/js/model_chooser.js
@@ -204,6 +204,14 @@ ModelChooser.prototype.setupWagtailWidget = function setupWagtailWidget(id, url)
         clear: function() {
             chooser.setState(null);
         },
+        getTextLabel: function(opts) {
+            if (!state) return null;
+            var result = state.display_title;
+            if (opts && opts.maxLength && result.length > opts.maxLength) {
+                return result.substring(0, opts.maxLength - 1) + '…';
+            }
+            return result;
+        },
         focus: () => {
             chooserElement.find('.action-choose').focus();
         },


### PR DESCRIPTION
Now collapsed blocks in the StreamField can use the object's display name as the header's title.

This is based on the snippet chooser's [current implementation](https://github.com/wagtail/wagtail/blob/af942a27e41b47e257b6cd46c01a13cd381fed04/client/src/entrypoints/snippets/snippet-chooser.js#L46), added with [this commit](https://github.com/wagtail/wagtail/commit/eb18d37986970c0b1fafb0f943593482d879c3b2).

Here the screens of an example `StructBlock` containing the `ModelChooserBlock`:
![example_open](https://user-images.githubusercontent.com/468164/156370351-3a59ffeb-6371-4da3-a5a2-aa8d3c7d0f3c.png)
Closing the block uses the title of the selected object:
![example_closed](https://user-images.githubusercontent.com/468164/156370398-120196a5-c80b-4f2c-bbe0-44c287165b66.png)

