### PR TITLE
Support for wagtail >= 3 module path changes

### DIFF
--- a/wagtailmodelchooser/blocks.py
+++ b/wagtailmodelchooser/blocks.py
@@ -1,6 +1,12 @@
 from django.utils.functional import cached_property, lazy
-from wagtail.core.blocks import ChooserBlock
-from wagtail.core.utils import resolve_model_string
+from wagtail import VERSION as WAGTAIL_VERSION
+
+if WAGTAIL_VERSION[0] >= 3:
+    from wagtail.blocks import ChooserBlock
+    from wagtail.coreutils import resolve_model_string
+else:
+    from wagtail.core.blocks import ChooserBlock
+    from wagtail.core.utils import resolve_model_string
 
 from . import registry
 from .widgets import AdminModelChooser

--- a/wagtailmodelchooser/version.py
+++ b/wagtailmodelchooser/version.py
@@ -1,2 +1,2 @@
-version_info = (2, 14, 0)
+version_info = (2, 14, 2)
 version = '.'.join(map(str, version_info))

--- a/wagtailmodelchooser/wagtail_hooks.py
+++ b/wagtailmodelchooser/wagtail_hooks.py
@@ -1,6 +1,11 @@
 from django.templatetags.static import static
 from django.utils.html import format_html
-from wagtail.core import hooks
+from wagtail import VERSION as WAGTAIL_VERSION
+
+if WAGTAIL_VERSION[0] >= 3:
+    from wagtail import hooks
+else:
+    from wagtail.core import hooks
 
 import wagtailmodelchooser.urls
 

--- a/wagtailmodelchooser/widgets.py
+++ b/wagtailmodelchooser/widgets.py
@@ -6,10 +6,14 @@ from django.utils.translation import gettext_lazy as _
 from wagtail import VERSION as WAGTAIL_VERSION
 from wagtail.admin.widgets import AdminChooser
 
-try:
+if WAGTAIL_VERSION[0] >= 3:
+    from wagtail.telepath import register
+    from wagtail.widget_adapters import WidgetAdapter
+elif WAGTAIL_VERSION[:2] >= (2, 13):
     from wagtail.core.telepath import register
     from wagtail.core.widget_adapters import WidgetAdapter
-except ImportError:  # do-nothing fallback for Wagtail <2.13
+else:  
+    # do-nothing fallback for Wagtail <2.13
     def register(adapter, cls):
         pass
 


### PR DESCRIPTION
Since Wagtail >= 4.?.? this was causing 5 deprecation warnings to be displayed.
https://docs.wagtail.org/en/stable/releases/3.0.html#changes-to-module-paths